### PR TITLE
Removed dependancy upon eventmachine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "http://rubygems.org"
 
-gem "eventmachine", "~>0.12.10"
 gem "libwebsocket", "~>0.1.0"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,6 @@ GEM
   remote: http://rubygems.org/
   specs:
     bacon (1.1.0)
-    eventmachine (0.12.10)
-    eventmachine (0.12.10-java)
     git (1.2.5)
     jeweler (1.5.2)
       bundler (~> 1.0.0)
@@ -21,7 +19,6 @@ PLATFORMS
 DEPENDENCIES
   bacon
   bundler (~> 1.0.0)
-  eventmachine (~> 0.12.10)
   jeweler (~> 1.5.2)
   libwebsocket (~> 0.1.0)
   rcov

--- a/pusher-client.gemspec
+++ b/pusher-client.gemspec
@@ -53,14 +53,12 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<eventmachine>, ["~> 0.12.10"])
       s.add_runtime_dependency(%q<libwebsocket>, ["~> 0.1.0"])
       s.add_development_dependency(%q<bacon>, [">= 0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.2"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
     else
-      s.add_dependency(%q<eventmachine>, ["~> 0.12.10"])
       s.add_dependency(%q<libwebsocket>, ["~> 0.1.0"])
       s.add_dependency(%q<bacon>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
@@ -68,7 +66,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rcov>, [">= 0"])
     end
   else
-    s.add_dependency(%q<eventmachine>, ["~> 0.12.10"])
     s.add_dependency(%q<libwebsocket>, ["~> 0.1.0"])
     s.add_dependency(%q<bacon>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])


### PR DESCRIPTION
eventmachine is no-longer used by the pusher-client gem, so I have removed the dependancy.
